### PR TITLE
Fix coordinates order in geospatial query example (point radius)

### DIFF
--- a/src/content/docs/using-the-api/geospatial.mdx
+++ b/src/content/docs/using-the-api/geospatial.mdx
@@ -88,7 +88,7 @@ search distance from the coordinate pair in meters, with a maximum value of
 To search around the point 136.90610, 35.14942 in Nagoya, Japan, the query
 parameters for the URL looks something like this:
 
-`?coordinates=136.90610,35.14942&radius=12000`
+`?coordinates=35.14942,136.90610&radius=12000`
 
 import radiusGeoJson from '@data/radius.json';
 


### PR DESCRIPTION
The coordinates given in the example are wrong, leading to internal server errors. Swapping these coordinates results in the correct response.